### PR TITLE
Add of code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 simple-cookie.sublime-project
 simple-cookie.sublime-workspace
+/test/coverage.html

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "lint": "jshint *.json *.js"
+    "lint": "jshint *.json *.js",
+    "test-cov": "mocha --require blanket -R html-cov > test/coverage.html"
   },
   "repository": {
     "type": "git",
@@ -21,10 +22,17 @@
     "url": "https://github.com/juji/simple-cookie/issues"
   },
   "homepage": "https://github.com/juji/simple-cookie",
+  "config": {
+      "blanket": {
+        "pattern": "index.js",
+        "data-cover-never" : "node_modules"
+      }
+    },
   "devDependencies": {
     "chai": "^1.9.1",
     "chai-as-promised": "^4.1.1",
     "mocha": "^1.21.4",
-    "jshint": "^2.5.11"
+    "jshint": "^2.5.11",
+    "blanket": "^1.1.6"
   }
 }


### PR DESCRIPTION
Code coverage is a measure used to describe the degree to which the source code
of a program is tested by a particular test suite.
Can be run with command:
npm run-script test-cov
And the result will be added in file of coverage.html
