### PR TITLE
Add of build passing badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - '0.10'
+  - '0.12'
+script: "npm run-script test"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 simple cookie serializer & parser for node.js
 
 [![NPM Version][npm-image]][npm-url]
+[![Build Status][travis-image]][travis-url]
 
 ##install
 npm install simple-cookie
@@ -61,3 +62,6 @@ chhers,
 [jujiyangasli.com](http://jujiyangasli.com)
 [npm-image]: https://img.shields.io/npm/v/simple-cookie.svg?style=flat
 [npm-url]: https://npmjs.org/package/simple-cookie
+
+[travis-image]: https://img.shields.io/travis/juji/simple-cookie.svg?style=flat
+[travis-url]: https://travis-ci.org/juji/simple-cookie

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "Simple cookie parser & serializer",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
     "lint": "jshint *.json *.js",
-    "test-cov": "mocha --require blanket -R html-cov > test/coverage.html"
+    "test": "jshint *.json *.js && mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With Travis CI, you can embed little status icons into your project's README or general documentation. That way, visitors of your projects or site can immediately see its build status.For it work, you must create/login your account on travis-ci.org (it's free) with your GitHub's account.
